### PR TITLE
Use multi-stage build in Docker to build the .jar file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
+FROM adoptopenjdk/maven-openjdk11 as build
+COPY . /build
+WORKDIR /build
+RUN mvn clean install
+
 FROM adoptopenjdk/openjdk11-openj9
 RUN groupadd -r codeclub && useradd -r -g codeclub codeclub
 ENV CODECLUB_HOME "/opt/codeclub"
 RUN mkdir -p "${CODECLUB_HOME}" && \
     chown -R codeclub:codeclub "${CODECLUB_HOME}"
-ADD --chown=codeclub:codeclub certificate-generator-web/target/certificate-generator-web.jar "${CODECLUB_HOME}"
+COPY --from=build /build/certificate-generator-web/target/certificate-generator-web.jar ${CODECLUB_HOME}/
 WORKDIR $CODECLUB_HOME
 EXPOSE 8080
 USER codeclub

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Gerador de Certificados Code Club Brasil
 # Demo app:
 https://certificategenerator.herokuapp.com/
 
-## Build:
-mvn clean install
-
 ## Build image:
 docker build --force-rm -t codeclubbrasil/gerador-certificados:java8 .
 


### PR DESCRIPTION
This PR improves the Dockerfile to run the build of the .jar file in a separate `build` stage.

This way the developer doesn't have to manually build it on his machine.

This shouldn't make the Docker image bigger because the build stage is not included in the final image.

Reference: https://docs.docker.com/build/building/multi-stage/